### PR TITLE
Read SMTP credentials from env

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,17 @@ npm run build
 npm start
 ```
 
+### Environment Variables
+
+Set the following variables in your hosting environment so the contact form can
+send email via SMTP:
+
+- `SMTP_USER` – your SMTP username
+- `SMTP_PASS` – your SMTP password
+
+These variables are required for `sendmail.php` to authenticate with your mail
+server in production.
+
 ---
 
 ## 🛠️ Tech Stack

--- a/sendmail.php
+++ b/sendmail.php
@@ -28,8 +28,9 @@ try {
     $mail->isSMTP();
     $mail->Host = 'smtp.hostinger.com';
     $mail->SMTPAuth = true;
-    $mail->Username = 'info@thenagabalm.com';
-    $mail->Password = 'Info,2025'; // Sécuriser plus tard via .env
+    // Credentials are read from environment variables for better security
+    $mail->Username = getenv('SMTP_USER');
+    $mail->Password = getenv('SMTP_PASS');
     $mail->SMTPSecure = PHPMailer::ENCRYPTION_SMTPS;
     $mail->Port = 465;
 


### PR DESCRIPTION
## Summary
- get SMTP credentials from env vars in `sendmail.php`
- explain SMTP_USER and SMTP_PASS setup in README

## Testing
- `npm install`
- `npm run lint` *(fails: ESLint prompts for configuration)*

------
https://chatgpt.com/codex/tasks/task_e_6848f27b4c1c832f8dfe920fb5e3cd27