### PR TITLE
Update sendmail.php to include phone and subject

### DIFF
--- a/sendmail.php
+++ b/sendmail.php
@@ -14,6 +14,8 @@ if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
 
 $name = htmlspecialchars(trim($_POST['name'] ?? ''));
 $email = htmlspecialchars(trim($_POST['email'] ?? ''));
+$phone = htmlspecialchars(trim($_POST['phone'] ?? ''));
+$subjectField = htmlspecialchars(trim($_POST['subject'] ?? ''));
 $message = htmlspecialchars(trim($_POST['message'] ?? ''));
 
 if (!$name || !$email || !$message) {
@@ -39,7 +41,7 @@ try {
 
     $mail->isHTML(true);
     $mail->Subject = 'Nouveau message du site';
-    $mail->Body    = "<b>Nom:</b> $name<br><b>Email:</b> $email<br><b>Message:</b><br>$message";
+    $mail->Body    = "<b>Nom:</b> $name<br><b>Email:</b> $email<br><b>Téléphone:</b> $phone<br><b>Sujet:</b> $subjectField<br><b>Message:</b><br>$message";
 
     $mail->send();
     echo json_encode(['status' => 'OK']);


### PR DESCRIPTION
## Summary
- read `phone` and `subject` from `$_POST`
- include both fields in the email body

## Testing
- `php -l sendmail.php`
- `npm install`
- `npm run lint` *(fails: prompts for setup)*

------
https://chatgpt.com/codex/tasks/task_e_6848f280a97c832fb017f78ad5ad592a