### PR TITLE
Add error handling in contact form submission

### DIFF
--- a/app/[locale]/contact/components/ContactFormSection.tsx
+++ b/app/[locale]/contact/components/ContactFormSection.tsx
@@ -13,13 +13,18 @@ const ContactFormSection = () => {
     e.preventDefault();
     const form = e.currentTarget;
     const data = new FormData(form);
-    const res = await fetch('/sendmail.php', { method: 'POST', body: data });
-    const json = await res.json();
-    if (res.ok && json.status === 'OK') {
-      alert('Message envoyé !');
-      form.reset();
-    } else {
-      alert('Erreur : ' + (json.error || 'Problème'));
+    try {
+      const res = await fetch('/sendmail.php', { method: 'POST', body: data });
+      const json = await res.json();
+      if (res.ok && json.status === 'OK') {
+        alert('Message envoyé !');
+        form.reset();
+      } else {
+        alert('Erreur : ' + (json.error || 'Problème'));
+      }
+    } catch (err) {
+      console.error(err);
+      alert('Erreur réseau');
     }
   };
 


### PR DESCRIPTION
## Summary
- handle network errors when submitting the contact form

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848f63af5b8832f840a4abd86686cbe